### PR TITLE
fix(rules): Fix the setting of noReactSpecificProps.

### DIFF
--- a/docs/rules/base/variables/base.md
+++ b/docs/rules/base/variables/base.md
@@ -1579,7 +1579,7 @@ Disables "quickfix" actions from being defined in Biome configuration. Left up t
 
 > `readonly` **noReactSpecificProps**: `"off"` = `"off"`
 
-React-only rule.
+Solid and qwik rule only.
 
 #### suspicious.noRedeclare
 

--- a/docs/rules/frontend/variables/frontend.md
+++ b/docs/rules/frontend/variables/frontend.md
@@ -1521,7 +1521,7 @@ Disables "quickfix" actions from being defined in Biome configuration. Left up t
 
 > `readonly` **noReactSpecificProps**: `"off"` = `"off"`
 
-React-only rule.
+Solid and qwik rule only.
 
 #### suspicious.noRedeclare
 

--- a/docs/rules/graphql/variables/graphql.md
+++ b/docs/rules/graphql/variables/graphql.md
@@ -1571,7 +1571,7 @@ Disables "quickfix" actions from being defined in Biome configuration. Left up t
 
 > `readonly` **noReactSpecificProps**: `"off"` = `"off"`
 
-React-only rule.
+Solid and qwik rule only.
 
 #### suspicious.noRedeclare
 

--- a/docs/rules/next/variables/next.md
+++ b/docs/rules/next/variables/next.md
@@ -1469,7 +1469,9 @@ Disables "quickfix" actions from being defined in Biome configuration. Left up t
 
 #### suspicious.noReactSpecificProps
 
-> `readonly` **noReactSpecificProps**: `"error"` = `"error"`
+> `readonly` **noReactSpecificProps**: `"off"` = `"off"`
+
+Solid and qwik rule only.
 
 #### suspicious.noRedeclare
 

--- a/docs/rules/node/variables/node.md
+++ b/docs/rules/node/variables/node.md
@@ -1573,7 +1573,7 @@ Disables "quickfix" actions from being defined in Biome configuration. Left up t
 
 > `readonly` **noReactSpecificProps**: `"off"` = `"off"`
 
-React-only rule.
+Solid and qwik rule only.
 
 #### suspicious.noRedeclare
 

--- a/docs/rules/react/variables/react.md
+++ b/docs/rules/react/variables/react.md
@@ -8,7 +8,7 @@
 
 > `const` **react**: `object`
 
-Defined in: [rules/react.ts:76](https://github.com/cookielab/biome-configuration/blob/main/src/rules/react.ts#L76)
+Defined in: [rules/react.ts:75](https://github.com/cookielab/biome-configuration/blob/main/src/rules/react.ts#L75)
 
 ## Type declaration
 
@@ -1477,7 +1477,9 @@ Disables "quickfix" actions from being defined in Biome configuration. Left up t
 
 #### suspicious.noReactSpecificProps
 
-> `readonly` **noReactSpecificProps**: `"error"` = `"error"`
+> `readonly` **noReactSpecificProps**: `"off"` = `"off"`
+
+Solid and qwik rule only.
 
 #### suspicious.noRedeclare
 

--- a/src/rules/base.ts
+++ b/src/rules/base.ts
@@ -660,7 +660,7 @@ const suspicious = {
 	noOctalEscape: "error",
 	noPrototypeBuiltins: "error",
 	/**
-	 * React-only rule.
+	 * Solid and qwik rule only.
 	 */
 	noReactSpecificProps: "off",
 	noRedeclare: "error",

--- a/src/rules/react.ts
+++ b/src/rules/react.ts
@@ -69,7 +69,6 @@ const suspicious = {
 	noArrayIndexKey: "error",
 	noCommentText: "error",
 	noDuplicateJsxProps: "error",
-	noReactSpecificProps: "error",
 	noSuspiciousSemicolonInJsx: "error",
 } as const satisfies z.infer<ReturnType<typeof suspiciousSchema.required>>;
 


### PR DESCRIPTION
## What

Disable the `noReactSpecificProps` for `react` and descendant rule-sets.

## Why

`noReactSpecificProps` is not a React-specific rule. It is meant to catch issues in `Solid` and `qwik`

## Changes

- Set `noReactSpecificProps` to `off` in `react`

## Testing

- [x] Tests pass
- [x] Manual testing

## Type

- [x] 🐛 Bug fix
- [ ] ✨ Feature
- [x] 📚 Documentation
- [ ] 🔧 Configuration
- [ ] ⚡ Performance
- [ ] Other:

## Checklist

- [x] Code follows project style
- [x] Tests added/updated
- [x] Documentation updated (if needed)
