### PR TITLE
feat(formatter): Change attributePosition from auto to multiline.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,11 @@
 - ## Changed
     - `"useConsistentMemberAccessibility": "error"` -> `"useConsistentMemberAccessibility": { "level": "error", options: { "accessibility": "explicit" } }`
 
+### Formatter Changes
+
+- ## Changed
+    - `"attributePosition": "auto"` -> `"attributePosition": "multiline"`
+
 ## v0.9.0
 
 ### General Changes

--- a/docs/base/variables/baseConfiguration.md
+++ b/docs/base/variables/baseConfiguration.md
@@ -135,7 +135,7 @@ Manual sorting is preferred.
 
 #### formatter.attributePosition
 
-> `readonly` **attributePosition**: `"auto"` = `"auto"`
+> `readonly` **attributePosition**: `"multiline"` = `"multiline"`
 
 #### formatter.bracketSameLine
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -70,7 +70,7 @@ const baseConfiguration = {
 	},
 
 	formatter: {
-		attributePosition: "auto",
+		attributePosition: "multiline",
 		bracketSameLine: false,
 		bracketSpacing: true,
 		enabled: true,


### PR DESCRIPTION
## What

Change `formatter.attributePosition` from `auto` to `multiline`.

## Why

To make all of HTML-like code look and behave the same during formatting.

## Changes

- `"attributePosition": "auto"` -> `"attributePosition": "multiline"`

## Testing

- [x] Tests pass
- [x] Manual testing

## Type

- [ ] 🐛 Bug fix
- [x] ✨ Feature
- [ ] 📚 Documentation
- [ ] 🔧 Configuration
- [ ] ⚡ Performance
- [ ] Other:

## Checklist

- [x] Code follows project style
- [ ] Tests added/updated
- [x] Documentation updated (if needed)
