### PR TITLE
fix: disable lint/nursery/useExportsLast

### DIFF
--- a/docs/rules/base/variables/base.md
+++ b/docs/rules/base/variables/base.md
@@ -8,7 +8,7 @@
 
 > `const` **base**: `object`
 
-Defined in: [rules/base.ts:1274](https://github.com/cookielab/biome-configuration/blob/main/src/rules/base.ts#L1274)
+Defined in: [rules/base.ts:1277](https://github.com/cookielab/biome-configuration/blob/main/src/rules/base.ts#L1277)
 
 ## Type Declaration
 
@@ -2034,7 +2034,9 @@ Enums are forbidden.
 
 #### style.useExportsLast
 
-> `readonly` **useExportsLast**: `"error"` = `"error"`
+> `readonly` **useExportsLast**: `"off"` = `"off"`
+
+Declaration-before-use for exports hurts readability.
 
 #### style.useExportType
 

--- a/docs/rules/frontend/variables/frontend.md
+++ b/docs/rules/frontend/variables/frontend.md
@@ -2012,7 +2012,9 @@ Enums are forbidden.
 
 #### style.useExportsLast
 
-> `readonly` **useExportsLast**: `"error"` = `"error"`
+> `readonly` **useExportsLast**: `"off"` = `"off"`
+
+Declaration-before-use for exports hurts readability.
 
 #### style.useExportType
 

--- a/docs/rules/graphql/variables/graphql.md
+++ b/docs/rules/graphql/variables/graphql.md
@@ -2042,7 +2042,9 @@ Enums are forbidden.
 
 #### style.useExportsLast
 
-> `readonly` **useExportsLast**: `"error"` = `"error"`
+> `readonly` **useExportsLast**: `"off"` = `"off"`
+
+Declaration-before-use for exports hurts readability.
 
 #### style.useExportType
 

--- a/docs/rules/next/variables/next.md
+++ b/docs/rules/next/variables/next.md
@@ -1974,7 +1974,9 @@ Enums are forbidden.
 
 #### style.useExportsLast
 
-> `readonly` **useExportsLast**: `"error"` = `"error"`
+> `readonly` **useExportsLast**: `"off"` = `"off"`
+
+Declaration-before-use for exports hurts readability.
 
 #### style.useExportType
 

--- a/docs/rules/node/variables/node.md
+++ b/docs/rules/node/variables/node.md
@@ -2032,7 +2032,9 @@ Enums are forbidden.
 
 #### style.useExportsLast
 
-> `readonly` **useExportsLast**: `"error"` = `"error"`
+> `readonly` **useExportsLast**: `"off"` = `"off"`
+
+Declaration-before-use for exports hurts readability.
 
 #### style.useExportType
 

--- a/docs/rules/react/variables/react.md
+++ b/docs/rules/react/variables/react.md
@@ -1980,7 +1980,9 @@ Enums are forbidden.
 
 #### style.useExportsLast
 
-> `readonly` **useExportsLast**: `"error"` = `"error"`
+> `readonly` **useExportsLast**: `"off"` = `"off"`
+
+Declaration-before-use for exports hurts readability.
 
 #### style.useExportType
 

--- a/src/rules/base.ts
+++ b/src/rules/base.ts
@@ -1023,7 +1023,10 @@ const style = {
 	useEnumInitializers: "off",
 	useExplicitLengthCheck: "error",
 	useExponentiationOperator: "error",
-	useExportsLast: "error",
+	/**
+	 * Declaration-before-use for exports hurts readability.
+	 */
+	useExportsLast: "off",
 	useExportType: "error",
 	/**
 	 * Should only be enabled per-project.


### PR DESCRIPTION
## What

Disable the `lint/nursery/useExportsLast` rule in the base configuration.

## Why

This rule enforces declaration-before-use for exports, which issue #2 identifies as harming readability without enough added value.

Closes #2.

## Changes

- changed `useExportsLast` from `"error"` to `"off"` in `src/rules/base.ts`
- regenerated rule docs for all affected configs

## Testing

- [x] Tests pass
- [x] Manual testing

Validated with:
- `pnpm build`
- `pnpm lint`
- `pnpm doc`

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📚 Documentation
- [x] 🔧 Configuration
- [ ] ⚡ Performance
- [ ] Other:

## Checklist

- [x] Code follows project style
- [ ] Tests added/updated
- [x] Documentation updated (if needed)
