### PR TITLE
fix: disable lint/complexity/noVoid

### DIFF
--- a/docs/rules/base/variables/base.md
+++ b/docs/rules/base/variables/base.md
@@ -8,7 +8,7 @@
 
 > `const` **base**: `object`
 
-Defined in: [rules/base.ts:1274](https://github.com/cookielab/biome-configuration/blob/main/src/rules/base.ts#L1274)
+Defined in: [rules/base.ts:1277](https://github.com/cookielab/biome-configuration/blob/main/src/rules/base.ts#L1277)
 
 ## Type Declaration
 
@@ -319,7 +319,9 @@ An `Option` or `Maybe` type would be more appropriate pattern for such usage, bu
 
 #### complexity.noVoid
 
-> `readonly` **noVoid**: `"error"` = `"error"`
+> `readonly` **noVoid**: `"off"` = `"off"`
+
+Using `void` to intentionally ignore callback return values is a useful shorthand.
 
 #### complexity.recommended
 

--- a/docs/rules/frontend/variables/frontend.md
+++ b/docs/rules/frontend/variables/frontend.md
@@ -317,7 +317,9 @@ An `Option` or `Maybe` type would be more appropriate pattern for such usage, bu
 
 #### complexity.noVoid
 
-> `readonly` **noVoid**: `"error"` = `"error"`
+> `readonly` **noVoid**: `"off"` = `"off"`
+
+Using `void` to intentionally ignore callback return values is a useful shorthand.
 
 #### complexity.recommended
 

--- a/docs/rules/graphql/variables/graphql.md
+++ b/docs/rules/graphql/variables/graphql.md
@@ -319,7 +319,9 @@ An `Option` or `Maybe` type would be more appropriate pattern for such usage, bu
 
 #### complexity.noVoid
 
-> `readonly` **noVoid**: `"error"` = `"error"`
+> `readonly` **noVoid**: `"off"` = `"off"`
+
+Using `void` to intentionally ignore callback return values is a useful shorthand.
 
 #### complexity.recommended
 

--- a/docs/rules/next/variables/next.md
+++ b/docs/rules/next/variables/next.md
@@ -315,7 +315,9 @@ An `Option` or `Maybe` type would be more appropriate pattern for such usage, bu
 
 #### complexity.noVoid
 
-> `readonly` **noVoid**: `"error"` = `"error"`
+> `readonly` **noVoid**: `"off"` = `"off"`
+
+Using `void` to intentionally ignore callback return values is a useful shorthand.
 
 #### complexity.recommended
 

--- a/docs/rules/node/variables/node.md
+++ b/docs/rules/node/variables/node.md
@@ -319,7 +319,9 @@ An `Option` or `Maybe` type would be more appropriate pattern for such usage, bu
 
 #### complexity.noVoid
 
-> `readonly` **noVoid**: `"error"` = `"error"`
+> `readonly` **noVoid**: `"off"` = `"off"`
+
+Using `void` to intentionally ignore callback return values is a useful shorthand.
 
 #### complexity.recommended
 

--- a/docs/rules/react/variables/react.md
+++ b/docs/rules/react/variables/react.md
@@ -315,7 +315,9 @@ An `Option` or `Maybe` type would be more appropriate pattern for such usage, bu
 
 #### complexity.noVoid
 
-> `readonly` **noVoid**: `"error"` = `"error"`
+> `readonly` **noVoid**: `"off"` = `"off"`
+
+Using `void` to intentionally ignore callback return values is a useful shorthand.
 
 #### complexity.recommended
 

--- a/src/rules/base.ts
+++ b/src/rules/base.ts
@@ -108,7 +108,10 @@ const complexity = {
 	 */
 	noUselessUndefined: "off",
 	noUselessUndefinedInitialization: "error",
-	noVoid: "error",
+	/**
+	 * Using `void` to intentionally ignore callback return values is a useful shorthand.
+	 */
+	noVoid: "off",
 	recommended: false,
 	useArrowFunction: "error",
 	useDateNow: "error",


### PR DESCRIPTION
## What

Disable the `lint/complexity/noVoid` rule in the base configuration.

## Why

Issue #33 points out that the main purpose of this rule is to discourage patterns like `void 0`, while our actual usage of `void` is to intentionally ignore sync or async callback return values.

Closes #33.

## Changes

- changed `noVoid` from `"error"` to `"off"` in `src/rules/base.ts`
- regenerated rule docs for all affected configs

## Testing

- [x] Tests pass
- [x] Manual testing

Validated with:
- `pnpm build`
- `pnpm lint`
- `pnpm doc`

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📚 Documentation
- [x] 🔧 Configuration
- [ ] ⚡ Performance
- [ ] Other:

## Checklist

- [x] Code follows project style
- [ ] Tests added/updated
- [x] Documentation updated (if needed)
