### PR TITLE
feat: customize lint/performance/noAwaitInLoops by environment

### DIFF
--- a/docs/rules/base/variables/base.md
+++ b/docs/rules/base/variables/base.md
@@ -8,7 +8,7 @@
 
 > `const` **base**: `object`
 
-Defined in: [rules/base.ts:1274](https://github.com/cookielab/biome-configuration/blob/main/src/rules/base.ts#L1274)
+Defined in: [rules/base.ts:1277](https://github.com/cookielab/biome-configuration/blob/main/src/rules/base.ts#L1277)
 
 ## Type Declaration
 
@@ -1649,7 +1649,9 @@ Vue-only rule.
 
 #### performance.noAwaitInLoops
 
-> `readonly` **noAwaitInLoops**: `"warn"` = `"warn"`
+> `readonly` **noAwaitInLoops**: `"off"` = `"off"`
+
+Sequential awaits in loops are sometimes the clearest and safest option.
 
 #### performance.noBarrelFile
 

--- a/docs/rules/frontend/variables/frontend.md
+++ b/docs/rules/frontend/variables/frontend.md
@@ -8,7 +8,7 @@
 
 > `const` **frontend**: `object`
 
-Defined in: [rules/frontend.ts:173](https://github.com/cookielab/biome-configuration/blob/main/src/rules/frontend.ts#L173)
+Defined in: [rules/frontend.ts:174](https://github.com/cookielab/biome-configuration/blob/main/src/rules/frontend.ts#L174)
 
 ## Type Declaration
 

--- a/docs/rules/graphql/variables/graphql.md
+++ b/docs/rules/graphql/variables/graphql.md
@@ -8,7 +8,7 @@
 
 > `const` **graphql**: `object`
 
-Defined in: [rules/graphql.ts:101](https://github.com/cookielab/biome-configuration/blob/main/src/rules/graphql.ts#L101)
+Defined in: [rules/graphql.ts:103](https://github.com/cookielab/biome-configuration/blob/main/src/rules/graphql.ts#L103)
 
 ## Type Declaration
 

--- a/docs/rules/next/variables/next.md
+++ b/docs/rules/next/variables/next.md
@@ -8,7 +8,7 @@
 
 > `const` **next**: `object`
 
-Defined in: [rules/next.ts:72](https://github.com/cookielab/biome-configuration/blob/main/src/rules/next.ts#L72)
+Defined in: [rules/next.ts:73](https://github.com/cookielab/biome-configuration/blob/main/src/rules/next.ts#L73)
 
 ## Type Declaration
 

--- a/docs/rules/node/variables/node.md
+++ b/docs/rules/node/variables/node.md
@@ -8,7 +8,7 @@
 
 > `const` **node**: `object`
 
-Defined in: [rules/node.ts:54](https://github.com/cookielab/biome-configuration/blob/main/src/rules/node.ts#L54)
+Defined in: [rules/node.ts:56](https://github.com/cookielab/biome-configuration/blob/main/src/rules/node.ts#L56)
 
 ## Type Declaration
 
@@ -1647,7 +1647,7 @@ Vue-only rule.
 
 #### performance.noAwaitInLoops
 
-> `readonly` **noAwaitInLoops**: `"warn"` = `"warn"`
+> `readonly` **noAwaitInLoops**: `"off"` = `"off"`
 
 #### performance.noBarrelFile
 

--- a/docs/rules/react/variables/react.md
+++ b/docs/rules/react/variables/react.md
@@ -8,7 +8,7 @@
 
 > `const` **react**: `object`
 
-Defined in: [rules/react.ts:128](https://github.com/cookielab/biome-configuration/blob/main/src/rules/react.ts#L128)
+Defined in: [rules/react.ts:130](https://github.com/cookielab/biome-configuration/blob/main/src/rules/react.ts#L130)
 
 ## Type Declaration
 

--- a/src/rules/base.ts
+++ b/src/rules/base.ts
@@ -849,7 +849,10 @@ const nursery = {
 
 const performance = {
 	noAccumulatingSpread: "error",
-	noAwaitInLoops: "warn",
+	/**
+	 * Sequential awaits in loops are sometimes the clearest and safest option.
+	 */
+	noAwaitInLoops: "off",
 	/**
 	 * Should only be enabled per-project.
 	 *

--- a/src/rules/frontend.ts
+++ b/src/rules/frontend.ts
@@ -136,6 +136,7 @@ const nursery = {
 const performance = {
 	...base.performance,
 
+	noAwaitInLoops: "warn",
 	useGoogleFontPreconnect: "error",
 } as const satisfies z.infer<ReturnType<typeof performanceSchema.required>>;
 

--- a/src/rules/graphql.ts
+++ b/src/rules/graphql.ts
@@ -74,6 +74,8 @@ const nursery = {
 
 const performance = {
 	...base.performance,
+
+	noAwaitInLoops: "warn",
 } as const satisfies z.infer<ReturnType<typeof performanceSchema.required>>;
 
 const security = {

--- a/src/rules/next.ts
+++ b/src/rules/next.ts
@@ -49,6 +49,7 @@ const nursery = {
 const performance = {
 	...react.performance,
 
+	noAwaitInLoops: "warn",
 	noImgElement: "error",
 	noUnwantedPolyfillio: "error",
 } as const satisfies z.infer<ReturnType<typeof performanceSchema.required>>;

--- a/src/rules/node.ts
+++ b/src/rules/node.ts
@@ -32,6 +32,8 @@ const nursery = {
 
 const performance = {
 	...base.performance,
+
+	noAwaitInLoops: "off",
 } as const satisfies z.infer<ReturnType<typeof performanceSchema.required>>;
 
 const security = {

--- a/src/rules/react.ts
+++ b/src/rules/react.ts
@@ -89,6 +89,8 @@ const nursery = {
 
 const performance = {
 	...frontend.performance,
+
+	noAwaitInLoops: "warn",
 } as const satisfies z.infer<ReturnType<typeof performanceSchema.required>>;
 
 const security = {


### PR DESCRIPTION
## What

Customize `lint/performance/noAwaitInLoops` by environment.

## Why

Sequential `await` inside loops is sometimes the clearest and safest implementation, especially in base and Node environments. Frontend-oriented configs should still keep this as a warning.

## Changes

- disabled `noAwaitInLoops` in `base`
- explicitly disabled `noAwaitInLoops` in `node`
- explicitly kept `noAwaitInLoops` as `warn` in `frontend`, `react`, `next`, and `graphql`
- regenerated rule docs for all affected configs

## Testing

- [x] Tests pass
- [x] Manual testing

Validated with:
- `pnpm build`
- `pnpm lint`
- `pnpm doc`

## Type

- [ ] 🐛 Bug fix
- [ ] ✨ Feature
- [ ] 📚 Documentation
- [x] 🔧 Configuration
- [ ] ⚡ Performance
- [ ] Other:

## Checklist

- [x] Code follows project style
- [ ] Tests added/updated
- [x] Documentation updated (if needed)
